### PR TITLE
Fix "# Building" reference to say "master_build.asm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ sram_variables.asm - Memory labels for the Save Memory in the NES memory (0x6000
 
 # Building
 
-Building the game is relatively simple. Download the repository. From the tools folder copy asm6f_32.exe and place it into the same folder as masterbuild.asm. You will also need a master copy of the original ROM. This goes into the same folder as masterbuild.asm as well. It needs to be named TSB.nes.
+Building the game is relatively simple. Download the repository. From the tools folder copy asm6f_32.exe and place it into the same folder as master_build.asm. You will also need a master copy of the original ROM. This goes into the same folder as master_build.asm as well. It needs to be named TSB.nes.
 
 Click on asm6.bat to open DOS command prompt in the same folder as master_build.asm and type:
 


### PR DESCRIPTION
Simple change to the README.md that fixes the name of a file referenced in the instructions. It's also to get me my first github pull-request. And, it gives me an excuse to ping bruddog :) 